### PR TITLE
Reinsert gatsby branch link

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,13 @@ module.exports = {
   plugins: [
     'gatsby-plugin-react-helmet',
     {
+      resolve: '@flockcover/gatsby-plugin-branch-web-sdk',	
+      options: {
+        prodBranchKey: 'key_live_jdrWlL9UY3OQcMssCT3ClbhkwvgXIaHJ',
+        devBranchKey: 'key_test_olq2fIWPX0NUeGxsyG1xFhohFFj2OhL0'
+      }
+    },
+    {
       resolve: 'gatsby-source-filesystem',
       options: {
         path: `${__dirname}/src/pages`,


### PR DESCRIPTION
After testing in netlify's staging deployment within an iOS and android device. This now works as it should.

Branch have been contacted to highlight the previous erroneous behaviour.