### PR TITLE
[FCOVO-1023] Add NonToggleiPhone component

### DIFF
--- a/src/components/NonToggleIphone.js
+++ b/src/components/NonToggleIphone.js
@@ -89,21 +89,24 @@ class NonToggleiPhone extends Component {
                 * {policyPauseSmallPrint}
               </Text>
             </Box>
-            <Box
-              order={[1, 3]}
-              zIndex="0"
-              width={['100%', '50%']}
-              height={[450, 450, 'auto']}
-            >
-              <Flex justifyContent="center" position="relative">
-                <div className={style.container}>
-                  <div className={style.screenContainer}>
-                    <img className={style.screen} src={withPrefix(image)} />
+
+            {image && (
+              <Box
+                order={[1, 3]}
+                zIndex="0"
+                width={['100%', '50%']}
+                height={[450, 450, 'auto']}
+              >
+                <Flex justifyContent="center" position="relative">
+                  <div className={style.container}>
+                    <div className={style.screenContainer}>
+                      <img className={style.screen} src={withPrefix(image)} />
+                    </div>
+                    <img src={iPhone} className={style.phone} />
                   </div>
-                  <img src={iPhone} className={style.phone} />
-                </div>
-              </Flex>
-            </Box>
+                </Flex>
+              </Box>
+            )}
           </Flex>
         </SiteContainer>
       </Flex>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -269,6 +269,32 @@ collections:
                   - name: rightIcon
                     label: Right Icon
                     widget: image
+          - name: how
+            label: How
+            widget: object
+            fields:
+              - name: title
+                label: Title
+                widget: string
+              - name: description
+                label: Description
+                widget: markdown
+              - name: image
+                label: Image
+                widget: image
+              - name: policyPauseSmallPrint
+                label: Policy Pause Small Print
+                widget: markdown
+              - name: list
+                label: List
+                widget: list
+                fields:
+                  - name: title
+                    label: Title
+                    widget: string
+                  - name: text
+                    label: Text
+                    widget: markdown
       - name: about
         label: About
         file: "src/pages/about.md"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -284,7 +284,7 @@ collections:
                 widget: image
               - name: policyPauseSmallPrint
                 label: Policy Pause Small Print
-                widget: markdown
+                widget: string
               - name: list
                 label: List
                 widget: list


### PR DESCRIPTION
## Add NonToggleiPhone component

**https://flockcover.atlassian.net/browse/FCOVO-1023**

### Acceptance Criteria

Everything configurable/optional/injectable. New bullet points addable/removable. Image in phone configurable

- New page has nontoggleiphone component
- Number of bullet points is editable - can be added, removed, or hidden entirely
- Each bullet point contains editable title and body. Body is richtext
- Global title is editable and hideable
- Global blurb is editable, hideable rich text
- iPhone is hideable, should autohide when no image provided
- images in iPhone are configurable
- Expose the above through netlify for the requisite screen

Testcase: Remove all paragraphs

### Manual testing

- Played with the markdown to make sure everything works ok.

### Known Issues

- None