### PR TITLE
remove old cms widgets post homepage redesign

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -74,19 +74,6 @@ collections:
                   - name: rightIcon
                     label: Right Icon
                     widget: image
-          - label: 'How Flock works'
-            name: 'howFlockWorks'
-            widget: 'object'
-            fields:
-              - {label: 'Title', name: 'title', widget: 'string'}
-              - {label: 'Description', name: 'description', widget: 'markdown'}
-              - label: 'List of how'
-                name: 'listOfHow'
-                widget: 'list'
-                fields:
-                  - {label: 'Title', name: 'title', widget: 'string'}
-                  - {label: 'Text', name: 'text', widget: 'markdown'}
-                  - {label: 'Image', name: 'image', widget: 'image'}
           - label: 'Stop worrying'
             name: 'stopWorrying'
             widget: 'object'
@@ -100,40 +87,6 @@ collections:
                   - {label: 'Title', name: 'title', widget: 'string'}
                   - {label: 'Text', name: 'text', widget: 'markdown'}
                   - {label: 'Icon', name: 'icon', widget: 'image'}
-          - label: 'What kind of pilot?'
-            name: 'kindOfPilot'
-            widget: 'object'
-            fields:
-              - {label: 'Title', name: 'title', widget: 'string'}
-              - {label: 'Description', name: 'description', widget: 'string'}
-              - label: 'Products'
-                name: 'products'
-                widget: 'list'
-                fields:
-                  - {label: 'Title', name: 'title', widget: 'string'}
-                  - {label: 'Text', name: 'text', widget: 'markdown'}
-                  - {label: 'Icon', name: 'icon', widget: 'image'}
-                  - {label: 'Link', name: 'link', widget: 'string'}
-          - label: 'Risk'
-            name: 'risk'
-            widget: 'object'
-            fields:
-              - {label: 'Title', name: 'title', widget: 'string'}
-              - {label: 'Description', name: 'description', widget: 'markdown'}
-              - label: 'List'
-                name: 'list'
-                widget: 'list'
-                fields:
-                  - {label: 'Title', name: 'title', widget: 'string'}
-                  - {label: 'Text', name: 'text', widget: 'markdown'}
-                  - {label: 'Icon', name: 'icon', widget: 'image'}
-          - label: 'Calculator'
-            name: 'calculator'
-            widget: 'object'
-            fields:
-              - {label: 'Title', name: 'title', widget: 'string'}
-              - {label: 'Description', name: 'description', widget: 'string'}
-              - {label: 'Disclaimer', name: 'disclaimer', widget: 'string'}
           - label: 'Second testimonials'
             name: 'secondTestimonial'
             widget: 'list'
@@ -155,6 +108,7 @@ collections:
               - {label: "Title", name: "title", widget: "string"}
               - {label: "Description", name: "description", widget: "string"}
               - {label: "Keywords", name: "keywords", widget: "list"}
+
       - name: settings
         label: Settings
         file: "src/pages/settings.md"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -121,6 +121,7 @@ collections:
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'string'}
               - {label: 'Keywords', name: 'keywords', widget: 'array'}
+
       - name: pricing
         label: Pricing
         file: "src/pages/pricing.md"
@@ -154,6 +155,7 @@ collections:
               - {label: "Title", name: "title", widget: "string"}
               - {label: "Description", name: "description", widget: "string"}
               - {label: "Keywords", name: "keywords", widget: "list"}
+
       - name: flyUnlimited
         label: Fly Unlimited
         file: "src/pages/flyUnlimited.md"
@@ -404,6 +406,7 @@ collections:
                 options:
                   - { label: Download, value: 'Application Download Viewed' }
                   - { label: Web App, value: 'WebApp Navigation Clicked' }
+
       - name: about
         label: About
         file: "src/pages/about.md"


### PR DESCRIPTION
There is no JIRA ticket for this but this will make the addition of the newer components into the CMS simpler.

You can view the simplified CMS interface here: https://deploy-preview-178--flockcover.netlify.com/admin/#/collections/pages/entries/home

