### PR TITLE
Add new homepage components to CMS

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -143,6 +143,7 @@ secondTestimonial:
     image: /images/uploads/testimonial/4.jpg
     quote: Easy to use and comprehensive insurance. Would highly recommend!
 renewalBanner:
+  hidden: false
   image: /images/uploads/renewal-drone.jpg
   mainText: Take to the skies with Flock today.
   buttonText: GET A PRICE IN 60 SECONDS

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -93,13 +93,15 @@ const HomeTemplate = ({
           </Box>
 
           <Box pt={[3, 5]} pb={[3, 5]}>
-            <RenewalBanner
-              image={renewalBanner.image}
-              mainText={renewalBanner.mainText}
-              buttonText={renewalBanner.buttonText}
-              buttonUrl={renewalBanner.buttonUrl}
-              buttonTrack={renewalBanner.buttonTrack}
-            />
+            {!renewalBanner.hidden && (
+              <RenewalBanner
+                image={renewalBanner.image}
+                mainText={renewalBanner.mainText}
+                buttonText={renewalBanner.buttonText}
+                buttonUrl={renewalBanner.buttonUrl}
+                buttonTrack={renewalBanner.buttonTrack}
+              />
+            )}
           </Box>
           <Featured title={featured.title} image={featured.image} />
         </div>
@@ -217,6 +219,7 @@ export const query = graphql`
           image
         }
         renewalBanner {
+          hidden
           image
           mainText
           buttonText

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -87,6 +87,38 @@ collections:
                   - {label: 'Title', name: 'title', widget: 'string'}
                   - {label: 'Text', name: 'text', widget: 'markdown'}
                   - {label: 'Icon', name: 'icon', widget: 'image'}
+          - label: 'Product Tabs'
+            name: 'productTabs'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'markdown'}
+              - label: Customer Type List
+                name: customerTypeList
+                widget: list
+                fields:
+                  - {label: 'Title', name: 'title', widget: 'string'}
+                  - {label: 'Customer Type Description', name: 'customerTypeDesc', widget: 'string'}
+                  - label: Product Cards
+                    name: productCards
+                    widget: list
+                    fields:
+                      - {label: 'Product Type', name: 'productType', widget: 'string'}
+                      - {label: 'Button One Text', name: 'buttonOneText', widget: 'string'}
+                      - {label: 'Button Two Text', name: 'buttonTwoText', widget: 'string'}
+                      - {label: 'Button One URL', name: 'buttonOneUrl', widget: 'string'}
+                      - {label: 'Button Two URL', name: 'buttonTwoUrl', widget: 'string'}
+                      - {label: 'Button One External', name: 'buttonOneExternal', widget: 'boolean'}
+                      - {label: 'Button Two External', name: 'buttonTwoExternal', widget: 'boolean'}
+                      - {label: 'From Price', name: 'fromPrice', widget: 'string'}
+                      - {label: 'From Text', name: 'fromText', widget: 'string'}
+                      - {label: 'Per Text', name: 'perText', widget: 'string'}
+                      - {label: 'Icon', name: 'icon', widget: 'string'}
+                      - label: Policy Feature List
+                        name: policyFeatureList
+                        widget: list
+                        fields:
+                          - {label: 'Text', name: 'text', widget: 'string'}
           - label: 'Second testimonials'
             name: 'secondTestimonial'
             widget: 'list'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -100,6 +100,32 @@ collections:
             fields:
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Image', name: 'image', widget: 'image'}
+          - name: renewalBanner
+            label: Renewal Banner
+            widget: object
+            fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
+              - name: image
+                label: Image
+                widget: image
+              - name: mainText
+                label: Main Text
+                widget: string
+              - name: buttonText
+                label: Button Text
+                widget: string
+              - name: buttonUrl
+                label: Button URL
+                widget: string
+              - name: buttonTrack
+                label: Button Track
+                widget: select
+                options:
+                  - { label: Download, value: 'Application Download Viewed' }
+                  - { label: Web App, value: 'WebApp Navigation Clicked' }
           - name: "siteMetadataOverride"
             required: false
             label: "Site metadata override"


### PR DESCRIPTION
This PR does the following:

1. Make the new Product Tab component editable
2. Make new Renewal Banner Component editable

Their respected JIRA tickets can be seen here:
https://flockcover.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=FCOVO&modal=detail&selectedIssue=FCOVO-1174&quickFilter=1
https://flockcover.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=FCOVO&modal=detail&selectedIssue=FCOVO-1175&quickFilter=1

You can view the content in the CMS here: https://deploy-preview-179--flockcover.netlify.com/admin/#/collections/pages/entries/home