### PR TITLE
Add all PAYF components to CMS

### DIFF
--- a/src/pages/flyUnlimited.md
+++ b/src/pages/flyUnlimited.md
@@ -114,6 +114,7 @@ whatIsCovered:
   fromText: from
   perText: per month**
 faqSection:
+  hidden: false
   header: Frequently asked questions
   body: Got other questions? Visit our help centre, or chat live with us now.
   buttonText: VIEW ALL FAQs

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -25,6 +25,7 @@ hero:
       title: 24/7 customer support
   header: 'Simpler, smarter drone insurance'
 stopWorrying:
+  hidden: false
   description: >-
     Our community helps to shape the products and features we build. The result: flexible policies that our pilots love, and smart tools that provide much more than just insurance.
   reasons:
@@ -42,6 +43,7 @@ stopWorrying:
       title: Backed by Allianz
   title: 'Built for drone pilots, with drone pilots'
 productTabs:
+  hidden: false
   title: Find the cover that's right for you
   description: Whether you’re operating commercially, completing your training, or flying for fun - we offer flexible cover that’s tailored to you.
   customerTypeList:
@@ -150,6 +152,7 @@ renewalBanner:
   buttonUrl: https://flockcover.app.link/6IW6kTmgfP
   buttonTrack: WebApp Navigation Clicked
 featured:
+  hidden: false
   image: images/uploads/featured-list.png
   title: As featured in
 siteMetadataOverride:

--- a/src/templates/flyUnlimited.js
+++ b/src/templates/flyUnlimited.js
@@ -123,16 +123,18 @@ class FlyUnlimitedPageTemplate extends Component {
             />
           )}
 
-          <Box className={css({backgroundColor: 'white'})}>
-            <FaqSection
-              header={faqSection.header}
-              body={faqSection.body}
-              buttonText={faqSection.buttonText}
-              buttonUrl={faqSection.buttonUrl}
-              disclosureIndicator={faqSection.disclosureIndicator}
-              faqs={faqSection.faqs}
-            />
-          </Box>
+          {!faqSection.hidden && (
+            <Box className={css({backgroundColor: 'white'})}>
+              <FaqSection
+                header={faqSection.header}
+                body={faqSection.body}
+                buttonText={faqSection.buttonText}
+                buttonUrl={faqSection.buttonUrl}
+                disclosureIndicator={faqSection.disclosureIndicator}
+                faqs={faqSection.faqs}
+              />
+            </Box>
+          )}
 
           <Footer />
         </div>
@@ -235,6 +237,7 @@ export const query = graphql`
           }
         }
         faqSection {
+          hidden
           header
           body
           buttonText

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -54,38 +54,42 @@ const HomeTemplate = ({
             buttons={hero.buttons}
             features={hero.features}
           />
-          <Box pt={[3, 3]} background="white">
-            <TextGrid
-              title={stopWorrying.title}
-              description={stopWorrying.description}
-              list={stopWorrying.reasons}
-            />
-          </Box>
-          <BigSectionLine id="product-tabs" />
+          {!stopWorrying.hidden && (
+            <Box pt={[3, 3]} background="white">
+              <TextGrid
+                title={stopWorrying.title}
+                description={stopWorrying.description}
+                list={stopWorrying.reasons}
+              />
+              <BigSectionLine id="product-tabs" />
+            </Box>
+          )}
         </Box>
 
-        <div className={css({backgroundColor: 'white'})}>
-          <Box background="white">
-            <TabSection
-              title={productTabs.title}
-              description={productTabs.description}
-            >
-              {productTabs.customerTypeList.map(
-                ({customerTypeDesc, productCards, title}) => (
-                  <TabSection.Tab title={title} key={title}>
-                    <Box pb={5}>
-                      <ProductCardTabs
-                        title={title}
-                        customerTypeDesc={customerTypeDesc}
-                        productCards={productCards}
-                      />
-                    </Box>
-                  </TabSection.Tab>
-                )
-              )}
-            </TabSection>
-          </Box>
-        </div>
+        {!productTabs.hidden && (
+          <div className={css({backgroundColor: 'white'})}>
+            <Box background="white">
+              <TabSection
+                title={productTabs.title}
+                description={productTabs.description}
+              >
+                {productTabs.customerTypeList.map(
+                  ({customerTypeDesc, productCards, title}) => (
+                    <TabSection.Tab title={title} key={title}>
+                      <Box pb={5}>
+                        <ProductCardTabs
+                          title={title}
+                          customerTypeDesc={customerTypeDesc}
+                          productCards={productCards}
+                        />
+                      </Box>
+                    </TabSection.Tab>
+                  )
+                )}
+              </TabSection>
+            </Box>
+          </div>
+        )}
 
         <div className={css({backgroundColor: 'white'})}>
           <Box pt={[3, 5]}>
@@ -103,7 +107,9 @@ const HomeTemplate = ({
               />
             )}
           </Box>
-          <Featured title={featured.title} image={featured.image} />
+          {!featured.hidden && (
+            <Featured title={featured.title} image={featured.image} />
+          )}
         </div>
         <Footer />
       </div>
@@ -201,6 +207,7 @@ export const query = graphql`
           }
         }
         stopWorrying {
+          hidden
           title
           description
           reasons {
@@ -215,6 +222,7 @@ export const query = graphql`
           image
         }
         featured {
+          hidden
           title
           image
         }
@@ -227,6 +235,7 @@ export const query = graphql`
           buttonTrack
         }
         productTabs {
+          hidden
           title
           description
           customerTypeList {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -113,7 +113,7 @@ collections:
                       - {label: 'From Price', name: 'fromPrice', widget: 'string'}
                       - {label: 'From Text', name: 'fromText', widget: 'string'}
                       - {label: 'Per Text', name: 'perText', widget: 'string'}
-                      - {label: 'Icon', name: 'icon', widget: 'string'}
+                      - {label: 'Icon', name: 'icon', widget: 'image'}
                       - label: Policy Feature List
                         name: policyFeatureList
                         widget: list
@@ -464,6 +464,220 @@ collections:
                 options:
                   - { label: Download, value: 'Application Download Viewed' }
                   - { label: Web App, value: 'WebApp Navigation Clicked' }
+
+
+      - name: payAsYouFly
+        label: Pay As You Fly
+        file: "src/pages/payAsYouFly.md"
+        fields:
+          - { label: Title, name: title, widget: string }
+          - { label: Template Key, name: templateKey, widget: hidden, default: payAsYouFly }
+          - name: hero
+            label: Hero
+            widget: object
+            fields:
+              - name: backgroundImage
+                label: Background Image
+                widget: image
+              - name: header
+                label: Header
+                widget: string
+              - name: description
+                label: Description
+                widget: markdown
+              - name: buttons
+                label: Buttons
+                widget: list
+                fields:
+                  - name: title
+                    label: Title
+                    widget: string
+                  - name: to
+                    label: To
+                    widget: string
+                  - name: color
+                    label: Color
+                    widget: select
+                    options:
+                      - { label: Yellow, value: yellow }
+                      - { label: Black, value: black }
+                    default: yellow
+                  - name: external
+                    label: External
+                    widget: boolean
+                  - name: branch
+                    label: Branch
+                    widget: boolean
+                  - name: track
+                    label: Track
+                    widget: select
+                    options:
+                      - { label: Download, value: 'Application Download Viewed' }
+                      - { label: Web App, value: 'WebApp Navigation Clicked' }
+              - name: features
+                label: Features
+                widget: list
+                fields:
+                  - name: title
+                    label: Title
+                    widget: string
+                  - name: leftIcon
+                    label: Left Icon
+                    widget: image
+                  - name: rightIcon
+                    label: Right Icon
+                    widget: image
+          - label: 'Stop worrying'
+            name: 'stopWorrying'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'markdown'}
+              - label: 'Reasons'
+                name: 'reasons'
+                widget: 'list'
+                fields:
+                  - {label: 'Title', name: 'title', widget: 'string'}
+                  - {label: 'Text', name: 'text', widget: 'markdown'}
+                  - {label: 'Icon', name: 'icon', widget: 'image'}
+          - label: 'How'
+            name: 'how'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'markdown'}
+              - label: 'List'
+                name: 'list'
+                widget: 'list'
+                fields:
+                  - {label: 'Title', name: 'title', widget: 'string'}
+                  - {label: 'Text', name: 'text', widget: 'markdown'}
+                  - {label: 'Image', name: 'image', widget: 'image'}
+          - label: 'Risk'
+            name: 'risk'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'markdown'}
+              - label: 'List'
+                name: 'list'
+                widget: 'list'
+                fields:
+                  - {label: 'Title', name: 'title', widget: 'string'}
+                  - {label: 'Text', name: 'text', widget: 'text'}
+                  - {label: 'Icon', name: 'icon', widget: 'image'}
+          - label: 'Calculator'
+            name: 'calculator'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'string'}
+              - {label: 'Disclaimer', name: 'disclaimer', widget: 'string'}
+          - label: 'Product Tabs'
+            name: 'productTabs'
+            widget: 'object'
+            fields:
+              - {label: 'Title', name: 'title', widget: 'string'}
+              - {label: 'Description', name: 'description', widget: 'markdown'}
+              - label: Customer Type List
+                name: customerTypeList
+                widget: list
+                fields:
+                  - {label: 'Title', name: 'title', widget: 'string'}
+                  - {label: 'Customer Type Description', name: 'customerTypeDesc', widget: 'string'}
+                  - label: 'What Is Covered'
+                    name: 'whatIsCovered'
+                    widget: 'object'
+                    fields:
+                      - {label: 'Main Title', name: 'mainTitle', widget: 'string'}
+                      - {label: 'Main Description', name: 'mainDescription', widget: 'string'}
+                      - {label: 'Product Type', name: 'productType', widget: 'string'}
+                      - {label: 'Button One Text', name: 'buttonOneText', widget: 'string'}
+                      - {label: 'Button Two Text', name: 'buttonTwoText', widget: 'string'}
+                      - {label: 'Button One URL', name: 'buttonOneUrl', widget: 'string'}
+                      - {label: 'Button Two URL', name: 'buttonTwoUrl', widget: 'string'}
+                      - {label: 'From Price', name: 'fromPrice', widget: 'string'}
+                      - {label: 'From Text', name: 'fromText', widget: 'string'}
+                      - {label: 'Per Text', name: 'perText', widget: 'string'}
+                      - {label: 'Sample Policy Wording URL', name: 'samplePolicyWordingUrl', widget: 'string'}
+                      - label: Policy Feature List
+                        name: policyFeatureList
+                        widget: list
+                        fields:
+                          - {label: 'Text', name: 'text', widget: 'string'}
+                      - name: smallPrints
+                        label: Small Prints
+                        widget: list
+                        fields:
+                          - name: text
+                            label: Text
+                            widget: string
+                      - name: mainList
+                        label: Main List
+                        widget: list
+                        fields:
+                          - name: title
+                            label: Text
+                            widget: string
+                          - name: icon
+                            label: Text
+                            widget: image
+
+          - name: renewalBanner
+            label: Renewal Banner
+            widget: object
+            fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
+              - name: image
+                label: Image
+                widget: image
+              - name: mainText
+                label: Main Text
+                widget: string
+              - name: buttonText
+                label: Button Text
+                widget: string
+              - name: buttonUrl
+                label: Button URL
+                widget: string
+              - name: buttonTrack
+                label: Button Track
+                widget: select
+                options:
+                  - { label: Download, value: 'Application Download Viewed' }
+                  - { label: Web App, value: 'WebApp Navigation Clicked' }
+          - name: faqSection
+            label: FAQ Section
+            widget: object
+            fields:
+              - name: header
+                label: Header
+                widget: string
+              - name: body
+                label: Body
+                widget: markdown
+              - name: buttonText
+                label: Button Text
+                widget: string
+              - name: buttonUrl
+                label: Button URL
+                widget: string
+              - name: disclosureIndicator
+                label: Disclosure Indicator
+                widget: image
+              - name: faqs
+                label: FAQ's
+                widget: list
+                fields:
+                  - name: title
+                    label: Title
+                    widget: string
+                  - name: body
+                    label: Body
+                    widget: markdown
 
       - name: about
         label: About

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -78,6 +78,10 @@ collections:
             name: 'stopWorrying'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: 'Reasons'
@@ -91,6 +95,10 @@ collections:
             name: 'productTabs'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: Customer Type List
@@ -123,6 +131,10 @@ collections:
             name: 'secondTestimonial'
             widget: 'list'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Author', name: 'author', widget: 'string'}
               - {label: 'Quote', name: 'quote', widget: 'markdown'}
               - {label: 'Image', name: 'image', widget: 'image'}
@@ -130,6 +142,10 @@ collections:
             name: 'featured'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Image', name: 'image', widget: 'image'}
           - name: renewalBanner
@@ -357,6 +373,10 @@ collections:
             label: FAQ Section
             widget: object
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - name: header
                 label: Header
                 widget: string
@@ -531,6 +551,10 @@ collections:
             name: 'stopWorrying'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: 'Reasons'
@@ -544,6 +568,10 @@ collections:
             name: 'how'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: 'List'
@@ -557,6 +585,10 @@ collections:
             name: 'risk'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: 'List'
@@ -570,6 +602,10 @@ collections:
             name: 'calculator'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'string'}
               - {label: 'Disclaimer', name: 'disclaimer', widget: 'string'}
@@ -577,6 +613,10 @@ collections:
             name: 'productTabs'
             widget: 'object'
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - {label: 'Title', name: 'title', widget: 'string'}
               - {label: 'Description', name: 'description', widget: 'markdown'}
               - label: Customer Type List
@@ -653,6 +693,10 @@ collections:
             label: FAQ Section
             widget: object
             fields:
+              - name: hidden
+                label: Hidden
+                widget: boolean
+                default: false
               - name: header
                 label: Header
                 widget: string


### PR DESCRIPTION
This PR does the following:

- Connect preexisting components on the PAYF page to admin interface
- Exposes the new components on the PAYF page to the admin interface

Their respective JIRA tickets can be seen below:

https://flockcover.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=FCOVO&modal=detail&selectedIssue=FCOVO-1178&quickFilter=1
https://flockcover.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=FCOVO&modal=detail&selectedIssue=FCOVO-1182&quickFilter=1

The data and components can be viewed in the CMS here:
https://deploy-preview-180--flockcover.netlify.com/admin/#/collections/pages/entries/payAsYouFly


This PR also adds a hide/show toggle for the FAQ component on the Fly Unlimited Page and to various components on the Home page.
